### PR TITLE
dev-java/osgi-annotation: with jdk-1.8 -> javac: invalid flag: --release

### DIFF
--- a/dev-java/osgi-annotation/osgi-annotation-6.0.0.ebuild
+++ b/dev-java/osgi-annotation/osgi-annotation-6.0.0.ebuild
@@ -19,7 +19,7 @@ SLOT="0"
 KEYWORDS="~amd64"
 
 DEPEND="app-arch/unzip:0
-	>=virtual/jdk-1.8"
+	>=virtual/jdk-1.9"
 
 RDEPEND=">=virtual/jre-1.8"
 


### PR DESCRIPTION
switching to jdk-1.9 fixes the issue, though then javadepchecker fails, but that's a different issue:

>>> Installing (1 of 1) dev-java/osgi-annotation-6.0.0::os-xtoo
 * checking 2 files for package collisions
>>> Merging dev-java/osgi-annotation-6.0.0 to /
Exception in thread "main" java.lang.NullPointerException
	at javadepchecker.Main.depsFound(Main.java:172)
	at javadepchecker.Main.checkPkg(Main.java:266)
	at javadepchecker.Main.main(Main.java:305)
--- /usr/
--- /usr/share/
>>> /usr/share/osgi-annotation/
>>> /usr/share/osgi-annotation/lib/
>>> /usr/share/osgi-annotation/lib/osgi-annotation.jar
>>> /usr/share/osgi-annotation/package.env
>>> dev-java/osgi-annotation-6.0.0 merged.
>>> Regenerating /etc/ld.so.cache...
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.