### PR TITLE
dev-java/lucene-core: jdk-1.8 -> javac: invalid flag: --release

### DIFF
--- a/dev-java/lucene-core/lucene-core-9999.ebuild
+++ b/dev-java/lucene-core/lucene-core-9999.ebuild
@@ -27,7 +27,7 @@ HOMEPAGE="https://lucene.apache.org/"
 LICENSE="Apache-2.0"
 SLOT="$(get_major_version)"
 
-DEPEND=">=virtual/jdk-1.8"
+DEPEND=">=virtual/jdk-1.9"
 
 RDEPEND=">=virtual/jre-1.8"
 


### PR DESCRIPTION
fails to compile with jdk-1.8. compiles fine with jdk-1.9.