### PR TITLE
dev-java/jnr-constants: jdk-1.8 -> javac: invalid flag: --release

### DIFF
--- a/dev-java/jnr-constants/jnr-constants-9999.ebuild
+++ b/dev-java/jnr-constants/jnr-constants-9999.ebuild
@@ -23,7 +23,7 @@ DESCRIPTION="Java Native Runtime constants"
 LICENSE="|| ( Apache-2.0 LGPL-3 )"
 SLOT="0"
 
-DEPEND=">=virtual/jdk-1.8"
+DEPEND=">=virtual/jdk-1.9"
 
 RDEPEND=">=virtual/jre-1.8"
 


### PR DESCRIPTION
fails to compile with jdk-1.8, compiles fine with jdk-1.9.