### PR TITLE
dev-java/bnd-annotation: jdk-1.8 -> javac: invalid flag: --release

### DIFF
--- a/dev-java/bnd-annotation/bnd-annotation-9999.ebuild
+++ b/dev-java/bnd-annotation/bnd-annotation-9999.ebuild
@@ -24,7 +24,7 @@ HOMEPAGE="https://www.aqute.biz/Bnd/Bnd"
 LICENSE="Apache-2.0"
 SLOT="$(get_major_version)"
 
-DEPEND=">=virtual/jdk-1.8"
+DEPEND=">=virtual/jdk-1.9"
 
 RDEPEND=">=virtual/jre-1.8"
 


### PR DESCRIPTION
fails to compile with jdk-1.8, compiles fine with jdk-1.9.