### PR TITLE
dev-java/jdepend: jdk-1.8 -> javac: invalid flag: --release

### DIFF
--- a/dev-java/jdepend/jdepend-9999.ebuild
+++ b/dev-java/jdepend/jdepend-9999.ebuild
@@ -22,7 +22,7 @@ HOMEPAGE="${BASE_URI}"
 LICENSE="BSD-3-clause"
 SLOT="0"
 
-DEPEND=">=virtual/jdk-1.8"
+DEPEND=">=virtual/jdk-1.9"
 
 RDEPEND=">=virtual/jre-1.8"
 


### PR DESCRIPTION
fails to compile with jdk-1.8, compiles fine with jdk-1.9.