### PR TITLE
dev-java/osgi-core-api: jdk-1.8 -> javac: invalid flag: --release

### DIFF
--- a/dev-java/osgi-core-api/osgi-core-api-6.0.0.ebuild
+++ b/dev-java/osgi-core-api/osgi-core-api-6.0.0.ebuild
@@ -19,7 +19,7 @@ CP_DEPEND="dev-java/osgi-annotation:0"
 
 DEPEND="app-arch/unzip:0
 	${CP_DEPEND}
-	>=virtual/jdk-1.8"
+	>=virtual/jdk-1.9"
 
 RDEPEND="${CP_DEPEND}
 	>=virtual/jre-1.8"


### PR DESCRIPTION
fails to compile with jdk-1.8, compiles fine with jdk-1.9.