### PR TITLE
dev-java/jansi-native: jdk-1.8 -> javac: invalid flag: --release

### DIFF
--- a/dev-java/jansi-native/jansi-native-9999.ebuild
+++ b/dev-java/jansi-native/jansi-native-9999.ebuild
@@ -27,7 +27,7 @@ SLOT="0"
 CP_DEPEND="dev-java/hawtjni-runtime:0"
 
 DEPEND="${CP_DEPEND}
-	>=virtual/jdk-1.8"
+	>=virtual/jdk-1.9"
 
 RDEPEND="${CP_DEPEND}
 	>=virtual/jre-1.8"


### PR DESCRIPTION
fails to compile with jdk-1.8, compiles fine with jdk-1.9.